### PR TITLE
acu81699 fixed download retriver attempting to override repo_dir declared in base class because there are other paths that call Base.repo_dir

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_scraper (3.2.1)
+    right_scraper (3.2.2)
       blackwinter-git (~> 1.2.7)
       json (~> 1.4)
       right_aws (>= 2.0)

--- a/right_scraper.gemspec
+++ b/right_scraper.gemspec
@@ -24,7 +24,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_scraper'
-  spec.version   = '3.2.1'
+  spec.version   = '3.2.2'
   spec.authors   = ['Graham Hughes', 'Raphael Simon', 'Scott Messier']
   spec.email     = 'raphael@rightscale.com'
   spec.homepage  = 'https://github.com/rightscale/right_scraper'


### PR DESCRIPTION
@ryanwilliamson hotfix release4.8

fixed issue with curl output (in case of error) raising exception because @output buffer was an array not a safe buffer

v3.2.2
