### PR TITLE
acu107715 rescue git errors at retriever load time to prevent process failing in cases where git is simply unavailable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_scraper (3.2.2)
+    right_scraper (3.2.3)
       blackwinter-git (~> 1.2.7)
       json (~> 1.4)
       right_aws (>= 2.0)
@@ -23,7 +23,7 @@ GEM
     columnize (0.3.6)
     diff-lcs (1.1.3)
     flexmock (0.9.0)
-    json (1.7.7)
+    json (1.8.0)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
     linecache19 (0.5.12)
@@ -31,9 +31,9 @@ GEM
     rake (0.8.7)
     rbx-require-relative (0.0.9)
     rdoc (2.5.11)
-    right_aws (3.0.5)
+    right_aws (3.1.0)
       right_http_connection (>= 1.2.5)
-    right_http_connection (1.3.0)
+    right_http_connection (1.4.0)
     right_support (2.7.0)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)

--- a/right_scraper.gemspec
+++ b/right_scraper.gemspec
@@ -24,7 +24,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name      = 'right_scraper'
-  spec.version   = '3.2.2'
+  spec.version   = '3.2.3'
   spec.authors   = ['Graham Hughes', 'Raphael Simon', 'Scott Messier']
   spec.email     = 'raphael@rightscale.com'
   spec.homepage  = 'https://github.com/rightscale/right_scraper'


### PR DESCRIPTION
@ryanwilliamson in lieu of replacing blackwinter-git
