### PR TITLE
Teal 13 18 acu138418 fix logger initialize under win env

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    right_scraper (4.0.2)
+    right_scraper (4.0.3)
       json (~> 1.4)
       right_aws (>= 2.0)
       right_git

--- a/lib/right_scraper/processes/warden.rb
+++ b/lib/right_scraper/processes/warden.rb
@@ -117,7 +117,7 @@ module RightScraper
       #
       # === Parameters
       # @param [String|Array] cmds to execute
-      # @param [Hash] copy_in files as map of host source path to jail destination path or empty or nil
+      # @param [String|Array] copy_in file(s) to copy into jail (using same path on both sides) or nil or empty
       # @param [Hash] copy_out files as map of jail source path to host destination path or empty or nil
       #
       # === Return
@@ -133,9 +133,8 @@ module RightScraper
         raise StateError, 'handle is invalid' unless @handle
 
         # copy any files in before running commands.
-        if copy_in && !copy_in.empty?
-          send_copy_in_cmds(copy_in)
-        end
+        copy_in = Array(copy_in)
+        send_copy_in_cmds(copy_in) if !copy_in.empty?
 
         # note that appending --privileged will run script as root, but we have
         # no use case for running scripts as root at this time.
@@ -181,6 +180,8 @@ module RightScraper
 
       # warden doesn't create directories on copy_in (or _out) so we need to
       # generate a script and execute it before invoking copy_in.
+      #
+      # @param [Array] copy_in as array of files to copy into jail
       def send_copy_in_cmds(copy_in)
         mkdir_cmds = copy_in.
           map { |dst_path| ::File.dirname(dst_path) }.uniq.sort.

--- a/lib/right_scraper/scanners/cookbook_metadata.rb
+++ b/lib/right_scraper/scanners/cookbook_metadata.rb
@@ -25,6 +25,8 @@
 require 'right_scraper/scanners'
 
 require 'json'
+require 'right_popen'
+require 'right_popen/safe_output_buffer'
 require 'tmpdir'
 
 module RightScraper::Scanners

--- a/lib/right_scraper/version.rb
+++ b/lib/right_scraper/version.rb
@@ -23,7 +23,7 @@
 
 module RightScraper
   # for gemspec, etc.
-  GEM_VERSION = '4.0.2'
+  GEM_VERSION = '4.0.3'
 
   # (Fixnum) protocol versioning scheme; prepended to hashes to
   # prevent collisions.

--- a/spec/processes/warden_spec.rb
+++ b/spec/processes/warden_spec.rb
@@ -228,7 +228,7 @@ describe RightScraper::Processes::Warden do
     it 'should run a command with jailed files' do
       ::Dir.mktmpdir do |tmpdir|
         in_files_dir_name = 'in_files'
-        jailed_files_dir_name = 'jailed_files'
+        jailed_files_dir_name = in_files_dir_name
         out_files_dir_name = 'out_files'
         result_file_name = 'result.txt'
 
@@ -246,12 +246,10 @@ describe RightScraper::Processes::Warden do
           "ls #{jailed_files_dir.inspect}",
           "echo success>#{jailed_result_path.inspect}"
         ]
-        copy_in = files.inject({}) do |result, name|
-          src_path = ::File.join(in_files_dir, name)
-          dst_path = ::File.join(jailed_files_dir, name)
-          fail "in-file does not exist: #{src_path.inspect}" unless ::File.file?(src_path)
-          result[src_path] = dst_path
-          result
+        copy_in = files.map do |name|
+          path = ::File.join(in_files_dir, name)
+          fail "in-file does not exist: #{path.inspect}" unless ::File.file?(path)
+          path
         end
         copy_out = { jailed_result_path => out_result_path }
         result = subject.run_command_in_jail(cmd, copy_in, copy_out)


### PR DESCRIPTION
@szmyd merge ivory's branch to master for v4, same fix already existed in right_scraper/loggers/default.rb so there is no actual change to default logger after merge.
fixed specs broken by change to create a cookbook tarball for warden to jail in release4.11
